### PR TITLE
vimPlugins.blink-cmp: add `updateScript`

### DIFF
--- a/pkgs/applications/editors/vim/plugins/blink-cmp/default.nix
+++ b/pkgs/applications/editors/vim/plugins/blink-cmp/default.nix
@@ -36,6 +36,9 @@ vimUtils.buildVimPlugin {
     mkdir -p target/release
     ln -s ${blink-fuzzy-lib}/lib/libblink_cmp_fuzzy.${libExt} target/release/libblink_cmp_fuzzy.${libExt}
   '';
+
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Performant, batteries-included completion plugin for Neovim";
     homepage = "https://github.com/saghen/blink.cmp";

--- a/pkgs/applications/editors/vim/plugins/blink-cmp/update.sh
+++ b/pkgs/applications/editors/vim/plugins/blink-cmp/update.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused jq
+
+set -euo pipefail
+
+cd "$(dirname "$0")" || exit 1
+
+# grab latest release version
+BLINK_CMP_LATEST_VER="$(curl --fail -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/Saghen/blink.cmp/releases/latest" | jq -r '.tag_name' | sed 's/^v//')"
+BLINK_CMP_CURRENT_VER="$(grep -oP 'version = "\K[^"]+' default.nix)"
+
+if [[ "$BLINK_CMP_LATEST_VER" == "$BLINK_CMP_CURRENT_VER" ]]; then
+    echo "blink.cmp is up-to-date"
+    exit 0
+fi
+
+# download updated Cargo.lock
+CARGO_LOCK_URL="https://raw.githubusercontent.com/Saghen/blink.cmp/refs/tags/v${BLINK_CMP_LATEST_VER}/Cargo.lock"
+curl --fail --output Cargo.lock "$CARGO_LOCK_URL"
+
+# update frizbee output hash, update blink.cmp hash
+FRIZBEE_COMMIT="$(grep -oP -m 1 '(?<=git\+https:\/\/github\.com\/saghen\/frizbee\#)[0-9a-f]{40}' Cargo.lock)"
+FRIZBEE_HASH="$(nix hash convert --hash-algo sha256 --to sri "$(nix-prefetch-url --type sha256 --unpack "https://github.com/saghen/frizbee/archive/${FRIZBEE_COMMIT}.tar.gz")")"
+BLINK_CMP_HASH="$(nix hash convert --hash-algo sha256 --to sri "$(nix-prefetch-url --type sha256 --unpack "https://github.com/Saghen/blink.cmp/archive/refs/tags/v${BLINK_CMP_LATEST_VER}.tar.gz")")"
+
+sed -i "s#hash = \".*\"#hash = \"$BLINK_CMP_HASH\"#g" default.nix
+sed -i "s#version = \".*\";#version = \"$BLINK_CMP_LATEST_VER\";#g" default.nix
+sed -i "s#\"frizbee-0.1.0\" = \".*\";#\"frizbee-0.1.0\" = \"$FRIZBEE_HASH\";#g" default.nix


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I have added a script to assist with the update process, grabbing the latest release of `blink.cmp`, pulling in the up-to-date `Cargo.lock` file, and making sure the `outputHashes` for the git-source `frizbee` crate is up to date.

## Things done
- added `update.sh` to `vimPlugins.blink-cmp`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
